### PR TITLE
argp.h: make code build on Mingw-w64

### DIFF
--- a/argp.h
+++ b/argp.h
@@ -397,14 +397,14 @@ struct argp_state
    routine returned a non-zero value, it is returned; otherwise 0 is
    returned.  This function may also call exit unless the ARGP_NO_HELP flag
    is set.  INPUT is a pointer to a value to be passed in to the parser.  */
-extern error_t argp_parse (const struct argp *__restrict __argp,
-			   int __argc, char **__restrict __argv,
-			   unsigned __flags, int *__restrict __arg_index,
-			   void *__restrict __input);
-extern error_t __argp_parse (const struct argp *__restrict __argp,
-			     int __argc, char **__restrict __argv,
-			     unsigned __flags, int *__restrict __arg_index,
-			     void *__restrict __input);
+extern error_t argp_parse (const struct argp *__restrict argp,
+			   int argc, char **__restrict argv,
+			   unsigned flags, int *__restrict arg_index,
+			   void *__restrict input);
+extern error_t __argp_parse (const struct argp *__restrict argp,
+			     int argc, char **__restrict argv,
+			     unsigned flags, int *__restrict arg_index,
+			     void *__restrict input);
 
 /* Global variables.  */
 


### PR DESCRIPTION
In Mingw-64 & GCC 11.2 the build fails as __argc and __argv are symbols
provided by stdlib.h. Fix by removing one underscore from argument names of
arg_parse and __argp_parse.

Change could be done also for just the __argc and __argv, but I suppose
the same naming convention could be used on all arguments of a function.

Errors fixed:
```
In file included from argp-standalone/argp-parse.c:65:
argp-standalone/argp-namefrob.h:27:22: error: conflicting types for 'argp_parse'; have 'error_t(const struct argp *, int,  char **, unsigned int,  int *, void *)' {aka 'int(const struct argp *, int,  char **, unsigned int,  int *, void *)'}
   27 | #define __argp_parse argp_parse
      |                      ^~~~~~~~~~
argp-standalone/argp-parse.c:872:1: note: in expansion of macro '__argp_parse'
  872 | __argp_parse (const struct argp *argp, int argc, char **argv, unsigned flags,
      | ^~~~~~~~~~~~
In file included from argp-standalone/argp-parse.c:64:
./argp-standalone/argp.h:400:16: note: previous declaration of 'argp_parse' with type 'error_t(const struct argp *, int *, char *** (*)(), unsigned int,  int *, void *)' {aka 'int(const struct argp *, int *, char *** (*)(), unsigned int,  int *, void *)'}
  400 | extern error_t argp_parse (const struct argp *__restrict __argp,
      |                ^~~~~~~~~~
```