### PR TITLE
Fix out of tree builds

### DIFF
--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -5,7 +5,8 @@ TS_ALL = $(TS_PROGS) $(TS_SH)
 
 noinst_PROGRAMS = $(TS_PROGS) ex1 ex3 ex4
 
-LDADD = ../libargp.a
+AM_CPPFLAGS = -I$(top_srcdir)
+LDADD = $(top_builddir)/libargp.a
 
 EXTRA_DIST = $(TS_SH) run-tests
 CLEANFILES = test.out


### PR DESCRIPTION
This addresses the errors when build is happening in a separate directory than the one containing source tree.