### PR TITLE
 Add libtool (for shared lib support) and install targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,18 +23,21 @@ SUBDIRS = . testsuite
 
 LIBOBJS = @LIBOBJS@
 
-noinst_LIBRARIES = libargp.a
 noinst_PROGRAMS = argp-test
-noinst_HEADERS = argp.h argp-fmtstream.h argp-namefrob.h # argp-comp.h
+noinst_HEADERS = argp-fmtstream.h argp-namefrob.h # argp-comp.h
 
 EXTRA_DIST = mempcpy.c strchrnul.c strndup.c Versions
 
+ACLOCAL_AMFLAGS = -I m4
+lib_LTLIBRARIES = libargp.la
 # Leaves out argp-fs-xinl.c and argp-xinl.c 
-libargp_a_SOURCES = argp-ba.c argp-eexst.c argp-fmtstream.c \
+libargp_la_SOURCES = argp-ba.c argp-eexst.c argp-fmtstream.c \
 		    argp-help.c argp-parse.c argp-pv.c \
 		    argp-pvh.c
+libargp_la_HEADERS = argp.h
+libargp_ladir = $(includedir)
 
-libargp_a_LIBADD = $(LIBOBJS)
+libargp_la_LIBADD = $(LIBOBJS)
 
-argp_test_LDADD = libargp.a
+argp_test_LDADD = libargp.la
 

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ dnl Process this file with autoconf to produce a configure script.
 dnl This configure.ac is only for building a standalone argp library.
 AC_PREREQ(2.54)
 AC_INIT(argp-ba.c)
-AM_INIT_AUTOMAKE(argp, standalone-1.4.0)
+AM_INIT_AUTOMAKE(argp, standalone-1.4.1)
 AM_CONFIG_HEADER(config.h)
 
 # GNU libc defaults to supplying the ISO C library functions only. The
@@ -17,6 +17,8 @@ AC_PROG_CC
 AC_PROG_MAKE_SET
 AC_PROG_RANLIB
 AM_PROG_CC_STDC
+
+LT_INIT
 
 if test "x$am_cv_prog_cc_stdc" = xno ; then
   AC_ERROR([the C compiler doesn't handle ANSI-C])
@@ -92,5 +94,7 @@ if test x$GCC = xyes ; then
 fi
 
 CPPFLAGS="$CPPFLAGS -I$srcdir"
+
+PKG_INSTALLDIR
 
 AC_OUTPUT(Makefile testsuite/Makefile)

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -5,7 +5,7 @@ TS_ALL = $(TS_PROGS) $(TS_SH)
 
 noinst_PROGRAMS = $(TS_PROGS) ex1 ex3 ex4
 
-LDADD = ../libargp.a
+LDADD = ../libargp.la
 
 EXTRA_DIST = $(TS_SH) run-tests
 CLEANFILES = test.out


### PR DESCRIPTION
- Use libtool, so libargp.so is built along with libargp.a
- Add installation targets so `make install` works